### PR TITLE
Add Subject Alternative Name support

### DIFF
--- a/examples/tlshelloworld.c
+++ b/examples/tlshelloworld.c
@@ -64,7 +64,7 @@ int verify_signature(struct TLSContext *context, struct TLSCertificate **certifi
     if (len) {
         struct TLSCertificate *cert = certificate_chain[0];
         if (cert) {
-            snprintf(identity_str, sizeof(identity_str), "%s, %s(%s) (issued by: %s)", cert->subject, cert->entity, cert->location, cert->issuer_entity);
+            snprintf(identity_str, sizeof(identity_str), "%s, %s(%s) (issued by: %s)", cert->subjects[0], cert->entity, cert->location, cert->issuer_entity);
             fprintf(stderr, "Verified: %s\n", identity_str);
         }
     }

--- a/tlse.c
+++ b/tlse.c
@@ -821,7 +821,8 @@ struct TLSCertificate {
     unsigned char *state;
     unsigned char *location;
     unsigned char *entity;
-    unsigned char *subject;
+    unsigned char **subjects;
+    unsigned int subjects_count;
     unsigned char *serial_number;
     unsigned int serial_len;
     unsigned char *sign_key;
@@ -1125,6 +1126,7 @@ static unsigned char state_oid[] = {0x55, 0x04, 0x08, 0x00};
 static unsigned char location_oid[] = {0x55, 0x04, 0x07, 0x00};
 static unsigned char entity_oid[] = {0x55, 0x04, 0x0A, 0x00};
 static unsigned char subject_oid[] = {0x55, 0x04, 0x03, 0x00};
+static unsigned char subject_alternate_oid[] = {0x55, 0x1D, 0x11, 0x00};
 
 static unsigned char TLS_RSA_SIGN_RSA_OID[] = {0x2A, 0x86, 0x48, 0x86, 0xF7, 0x0D, 0x01, 0x01, 0x01, 0x00};
 static unsigned char TLS_RSA_SIGN_MD5_OID[] = {0x2A, 0x86, 0x48, 0x86, 0xF7, 0x0D, 0x01, 0x01, 0x04, 0x00};
@@ -2506,25 +2508,22 @@ struct TLSCertificate *tls_create_certificate() {
     return cert;
 }
 
-int tls_certificate_valid_subject(struct TLSCertificate *cert, const char *subject) {
-    if (!cert)
-        return certificate_unknown;
-    
+static int tls_certificate_subject_match(const char *certsubject, const char *subject) {
     // no subjects ...
-    if (((!cert->subject) || (!cert->subject[0])) && ((!subject) || (!subject[0])))
+    if (((!certsubject) || (!certsubject[0])) && ((!subject) || (!subject[0])))
         return 0;
     
     if ((!subject) || (!subject[0]))
         return bad_certificate;
     
-    if ((!cert->subject) || (!cert->subject[0]))
+    if ((!certsubject) || (!certsubject[0]))
         return bad_certificate;
     
     // exact match
-    if (!strcmp((const char *)cert->subject, subject))
+    if (!strcmp((const char *)certsubject, subject))
         return 0;
     
-    const char *wildcard = strchr((const char *)cert->subject, '*');
+    const char *wildcard = strchr((const char *)certsubject, '*');
     if (wildcard) {
         // 6.4.3 (1) The client SHOULD NOT attempt to match a presented identifier in
         // which the wildcard character comprises a label other than the left-most label
@@ -2555,6 +2554,20 @@ int tls_certificate_valid_subject(struct TLSCertificate *cert, const char *subje
         }
     }
     
+    return bad_certificate;
+}
+
+int tls_certificate_valid_subject(struct TLSCertificate *cert, const char *subject) {
+    unsigned int i;
+    
+    if (!cert)
+        return certificate_unknown;
+    
+    for (i=0;i<cert->subjects_count;i++) {
+        if (tls_certificate_subject_match(cert->subjects[i], subject) == 0) {
+            return 0;
+        }
+    }
     return bad_certificate;
 }
 
@@ -2656,7 +2669,7 @@ char *tls_certificate_to_string(struct TLSCertificate *cert, char *buffer, int l
                            (int)cert->version,
                            cert->issuer_country, cert->issuer_entity, cert->issuer_subject,
                            cert->country, cert->entity, cert->state, cert->location,
-                           cert->subject,
+                           cert->subjects[0],
                            cert->not_before, cert->not_after
                            );
         if (res > 0) {
@@ -2865,6 +2878,7 @@ void tls_certificate_set_algorithm(unsigned int *algorithm, const unsigned char 
 
 void tls_destroy_certificate(struct TLSCertificate *cert) {
     if (cert) {
+        unsigned int i;
         TLS_FREE(cert->exponent);
         TLS_FREE(cert->pk);
         TLS_FREE(cert->issuer_country);
@@ -2875,7 +2889,10 @@ void tls_destroy_certificate(struct TLSCertificate *cert) {
         TLS_FREE(cert->country);
         TLS_FREE(cert->state);
         TLS_FREE(cert->location);
-        TLS_FREE(cert->subject);
+        for (i=0;i<cert->subjects_count;i++) {
+            TLS_FREE(cert->subjects[i]);
+        }
+        TLS_FREE(cert->subjects);
         TLS_FREE(cert->serial_number);
         TLS_FREE(cert->entity);
         TLS_FREE(cert->not_before);
@@ -6338,7 +6355,7 @@ int tls_certificate_chain_is_valid_root(struct TLSContext *context, struct TLSCe
     return bad_certificate;
 }
 
-int __private_asn1_parse(struct TLSContext *context, struct TLSCertificate *cert, const unsigned char *buffer, int size, int level, unsigned int *fields, unsigned char *has_key, int client_cert, unsigned char *top_oid) {
+int __private_asn1_parse(struct TLSContext *context, struct TLSCertificate *cert, const unsigned char *buffer, int size, int level, unsigned int *fields, unsigned char *has_key, int client_cert, unsigned char *top_oid, unsigned char san_state) {
     int pos = 0;
     // X.690
     int idx = 0;
@@ -6413,7 +6430,7 @@ int __private_asn1_parse(struct TLSContext *context, struct TLSCertificate *cert
                     DEBUG_PRINT("CONSTRUCT TYPE %02X\n", (int)type);
             }
             local_has_key = 0;
-            __private_asn1_parse(context, cert, &buffer[pos], length, level + 1, fields, &local_has_key, client_cert, top_oid);
+            __private_asn1_parse(context, cert, &buffer[pos], length, level + 1, fields, &local_has_key, client_cert, top_oid, (san_state==1) ? 2 : 0);
             if ((((local_has_key) && (context) && ((!context->is_server) || (client_cert))) || (!context)) && (__is_field(fields, pk_id))) {
                 TLS_FREE(cert->der_bytes);
                 temp = length + (pos - start_pos);
@@ -6460,9 +6477,17 @@ int __private_asn1_parse(struct TLSContext *context, struct TLSCertificate *cert
                         if (__is_field(fields_temp, priv_id))
                             tls_certificate_set_priv(cert, &buffer[pos], length);
                     }
-                    DEBUG_PRINT("INTEGER(%i): ", length);
-                    DEBUG_DUMP_HEX(&buffer[pos], length);
-                    DEBUG_PRINT("\n");
+                    if (san_state==2) {
+                        cert->subjects = TLS_REALLOC(cert->subjects, sizeof(unsigned char *) * (cert->subjects_count+1));
+                        cert->subjects[cert->subjects_count] = NULL;
+                        tls_certificate_set_copy(&cert->subjects[cert->subjects_count], &buffer[pos], length);
+                        cert->subjects_count++;
+                        DEBUG_PRINT("SUBJECT ALTERNATIVE NAME(%i): %.*s\n", length, length, &buffer[pos]);
+                    } else {
+                        DEBUG_PRINT("INTEGER(%i): ", length);
+                        DEBUG_DUMP_HEX(&buffer[pos], length);
+                        DEBUG_PRINT("\n");
+                    }
                     break;
                 case 0x03:
                     // bitstream
@@ -6476,9 +6501,9 @@ int __private_asn1_parse(struct TLSContext *context, struct TLSCertificate *cert
                         tls_certificate_set_key(cert, &buffer[pos], length);
                     } else {
                         if ((buffer[pos] == 0x00) && (length > 256))
-                            __private_asn1_parse(context, cert, &buffer[pos]+1, length - 1, level + 1, fields, &local_has_key, client_cert, top_oid);
+                            __private_asn1_parse(context, cert, &buffer[pos]+1, length - 1, level + 1, fields, &local_has_key, client_cert, top_oid, 0);
                         else
-                            __private_asn1_parse(context, cert, &buffer[pos], length, level + 1, fields, &local_has_key, client_cert, top_oid);
+                            __private_asn1_parse(context, cert, &buffer[pos], length, level + 1, fields, &local_has_key, client_cert, top_oid, 0);
                         
                         if (top_oid) {
                             if (__is_oid2(top_oid, TLS_EC_prime256v1_OID, sizeof(oid), sizeof(TLS_EC_prime256v1) - 1)) {
@@ -6499,13 +6524,16 @@ int __private_asn1_parse(struct TLSContext *context, struct TLSCertificate *cert
                     }
                     break;
                 case 0x04:
+                    if (__is_oid(oid, subject_alternate_oid, 3)) {
+                        __private_asn1_parse(context, cert, &buffer[pos], length, level + 1, fields, &local_has_key, client_cert, top_oid, 1);
+                    } else
                     if ((top_oid) && (__is_field(fields, ecc_priv_id)) && (!cert->priv)) {
                         DEBUG_PRINT("BINARY STRING(%i): ", length);
                         DEBUG_DUMP_HEX(&buffer[pos], length);
                         DEBUG_PRINT("\n");
                         tls_certificate_set_priv(cert, &buffer[pos], length);
                     } else
-                        __private_asn1_parse(context, cert, &buffer[pos], length, level + 1, fields, &local_has_key, client_cert, top_oid);
+                        __private_asn1_parse(context, cert, &buffer[pos], length, level + 1, fields, &local_has_key, client_cert, top_oid, 0);
                     break;
                 case 0x05:
                     DEBUG_PRINT("NULL\n");
@@ -6596,8 +6624,12 @@ int __private_asn1_parse(struct TLSContext *context, struct TLSCertificate *cert
                         if (__is_oid(oid, entity_oid, 3))
                             tls_certificate_set_copy(&cert->entity, &buffer[pos], length);
                         else
-                        if (__is_oid(oid, subject_oid, 3))
-                            tls_certificate_set_copy(&cert->subject, &buffer[pos], length);
+                        if (__is_oid(oid, subject_oid, 3)) {
+                            cert->subjects = TLS_REALLOC(cert->subjects, sizeof(unsigned char *) * (cert->subjects_count+1));
+                            cert->subjects[cert->subjects_count] = NULL;
+                            tls_certificate_set_copy(&cert->subjects[cert->subjects_count], &buffer[pos], length);
+                            cert->subjects_count++;
+                        }
                     }
                     DEBUG_PRINT("STR: [");
                     DEBUG_DUMP(&buffer[pos], length);
@@ -6641,9 +6673,9 @@ struct TLSCertificate *asn1_parse(struct TLSContext *context, const unsigned cha
             // private key
             unsigned char top_oid[16];
             memset(top_oid, 0, sizeof(top_oid));
-            __private_asn1_parse(context, cert, buffer, size, 1, fields, NULL, client_cert, top_oid);
+            __private_asn1_parse(context, cert, buffer, size, 1, fields, NULL, client_cert, top_oid, 0);
         } else
-            __private_asn1_parse(context, cert, buffer, size, 1, fields, NULL, client_cert, NULL);
+            __private_asn1_parse(context, cert, buffer, size, 1, fields, NULL, client_cert, NULL, 0);
     }
     return cert;
 }


### PR DESCRIPTION
The san_state variable feels like wrong solution, but I couldn't find anything better. If you can, I'll be glad to rewrite it.