### PR TITLE
setsockopt() before bind() at examples/{tlshelloworld,tlssimpleserver}.c

### DIFF
--- a/examples/tlshelloworld.c
+++ b/examples/tlshelloworld.c
@@ -119,12 +119,13 @@ int main(int argc , char *argv[]) {
     server.sin_addr.s_addr = INADDR_ANY;
     server.sin_port = htons(port);
      
+    int enable = 1;
+    setsockopt(socket_desc, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(int));
+
     if( bind(socket_desc,(struct sockaddr *)&server , sizeof(server)) < 0) {
         perror("bind failed. Error");
         return 1;
     }
-    int enable = 1;
-    setsockopt(socket_desc, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(int));
      
     listen(socket_desc , 3);
      

--- a/examples/tlssimpleserver.c
+++ b/examples/tlssimpleserver.c
@@ -35,12 +35,13 @@ int main(int argc , char *argv[]) {
     server.sin_addr.s_addr = INADDR_ANY;
     server.sin_port = htons(2000);
      
+    int enable = 1;
+    setsockopt(socket_desc, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(int));
+
     if( bind(socket_desc,(struct sockaddr *)&server , sizeof(server)) < 0) {
         perror("bind failed. Error");
         return 1;
     }
-    int enable = 1;
-    setsockopt(socket_desc, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(int));
      
     listen(socket_desc , 3);
      


### PR DESCRIPTION
Reusing adress is possible only if setsockopt() function is called before bind() ( tested only on Linux 3.10.18 ).

PS. Thanks you for this project it is exactly what i was searching (import/export context is realy cool thing which one is not possible on OpenSSL/LibreSSL).