### PR TITLE
Discard incorret unused sleep define

### DIFF
--- a/examples/tlshelloworld.c
+++ b/examples/tlshelloworld.c
@@ -5,7 +5,6 @@
 #ifdef _WIN32
     #include <winsock2.h>
     #define socklen_t int
-    #define sleep(x)    Sleep(x*1000)
 #else
     #include <sys/socket.h>
     #include <arpa/inet.h>


### PR DESCRIPTION
Usually it is x / 1000 not * 1000. Anyway the sleep function is not called in the code so it is safe to remove IMO. Please double check.