### PR TITLE
docs: fix simple typo, unordeded -> unordered

### DIFF
--- a/libtomcrypt.c
+++ b/libtomcrypt.c
@@ -18855,7 +18855,7 @@ int der_decode_printable_string(const unsigned char *in, unsigned long inlen,
    @param inlen    The size of the input
    @param list     The list of items to decode
    @param outlen   The number of items in the list
-   @param ordered  Search an unordeded or ordered list
+   @param ordered  Search an unordered or ordered list
    @return CRYPT_OK on success
  */
 int der_decode_sequence_ex(const unsigned char *in, unsigned long inlen,


### PR DESCRIPTION
There is a small typo in libtomcrypt.c.

Should read `unordered` rather than `unordeded`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md