### PR TITLE
[FIX] parse supported_versions extension

### DIFF
--- a/tlse.c
+++ b/tlse.c
@@ -6649,12 +6649,11 @@ int tls_parse_hello(struct TLSContext *context, const unsigned char *buf, int bu
             if (extension_type == 0x2B) {
                 // supported versions
                 if ((context->is_server) && (buf[res] == extension_len - 1)) {
-                    if (extension_len > 4) {
+                    if (extension_len > 2) {
                         DEBUG_DUMP_HEX_LABEL("SUPPORTED VERSIONS", &buf[res], extension_len);
                         int i;
                         int limit = (int)buf[res];
                         if (limit == extension_len - 1) {
-                            limit--;
                             for (i = 1; i < limit; i += 2) {
                                 if ((ntohs(*(unsigned short *)&buf[res + i]) == TLS_V13) || (ntohs(*(unsigned short *)&buf[res + i]) == 0x7F1C)) {
                                     context->version = TLS_V13;


### PR DESCRIPTION
Currently the parsing function expects at least two supported versions (5+ bytes). TLSe client implementation provides those (0x0304 and draft 28), so it's working.
But other clients (like openssl) might only provide one version which should also be accepted. Thus I removed the corresponding check.

Fixes #65 