### PR TITLE
Fix compilation when `complex.h` is included

### DIFF
--- a/tlse.c
+++ b/tlse.c
@@ -48,7 +48,15 @@
 #endif
 
 #ifdef TLS_AMALGAMATION
+#ifdef I
+#define TLS_I_MACRO I
+#undef I
+#endif
 #include "libtomcrypt.c"
+#ifdef TLS_I_MACRO
+#define I TLS_I_MACRO
+#undef TLS_I_MACRO
+#endif
 #else
 #include <tomcrypt.h>
 #endif

--- a/tlse.c
+++ b/tlse.c
@@ -49,12 +49,13 @@
 
 #ifdef TLS_AMALGAMATION
 #ifdef I
-#define TLS_I_MACRO I
+#pragma push_macro("I")
+#define TLS_I_MACRO
 #undef I
 #endif
 #include "libtomcrypt.c"
 #ifdef TLS_I_MACRO
-#define I TLS_I_MACRO
+#pragma pop_macro("I")
 #undef TLS_I_MACRO
 #endif
 #else


### PR DESCRIPTION
`complex.h` defines an `I` macro, which conflicts with `libtomcrypt.c`.

Thanks for this awesome library, by the way!