### PR TITLE
stop gcc from annoying in Debug mode

### DIFF
--- a/tlse.c
+++ b/tlse.c
@@ -3466,7 +3466,7 @@ int tls_certificate_is_valid(struct TLSCertificate *cert) {
     struct tm *utct = gmtime(&t);
     if (utct) {
         current_time[0] = 0;
-        snprintf(current_time, sizeof(current_time), "%04d%02d%02d%02d%02d%02dZ", 1900 + utct->tm_year, utct->tm_mon + 1, utct->tm_mday, utct->tm_hour, utct->tm_min, utct->tm_sec);
+        snprintf(current_time, sizeof(current_time), "%04hu%02hhu%02hhu%02hhu%02hhu%02hhuZ", 1900 + utct->tm_year, utct->tm_mon + 1, utct->tm_mday, utct->tm_hour, utct->tm_min, utct->tm_sec);
         if (strcasecmp((char *)cert->not_before, current_time) > 0) {
             DEBUG_PRINT("Certificate is not yer valid, now: %s (validity: %s - %s)\n", current_time, cert->not_before, cert->not_after);
             return certificate_expired;


### PR DESCRIPTION
This fixes up a warning given by a modern gcc reasonably thinking that there might be an output exceeding the capacity of memory provided for the string of time-zone